### PR TITLE
Add the ability to sign a request before it is sent out, and also decode the response.

### DIFF
--- a/src/ux/Fileup.js
+++ b/src/ux/Fileup.js
@@ -437,7 +437,7 @@ Ext.define('Ext.ux.Fileup', {
                 if (this.readyState == 4) {
                     if(this.status == 200) {
                         
-                        var response = Ext.decode(this.responseText, true)
+                        var response = me.decodeResponse(this);
                         
                         if (response && response.success) {
                             // Success
@@ -487,6 +487,19 @@ Ext.define('Ext.ux.Fileup', {
      */
     signRequest: function(http, callback) {
       callback(http);
+    },
+
+    /**
+     * Decodes a server response.
+     *
+     * @param {object} response
+     *   The response from the server to decode.
+     *
+     * @return {object}
+     *   The response to provide to the library.
+     */
+    decodeResponse: function(response) {
+      return Ext.decode(response.responseText, true);
     },
 
     /**

--- a/src/ux/Fileup.js
+++ b/src/ux/Fileup.js
@@ -468,9 +468,27 @@ Ext.define('Ext.ux.Fileup', {
         
         // Send form with file using XMLHttpRequest POST request
         http.open('POST', me.getUrl());
-        http.send(me.getForm(file));
+
+        // Sign the request and then send.
+        me.signRequest(http, function(http) {
+
+          // Send the form.
+          http.send(me.getForm(file));
+        });
     },
     
+    /**
+     * Sign the request before sending it.
+     *
+     * @param {object} request
+     *   The XHR request object.
+     * @param {function} callback
+     *   Called when the request has been signed.
+     */
+    signRequest: function(http, callback) {
+      callback(http);
+    },
+
     /**
      * @method getForm
      * Returns the form to send to the browser.


### PR DESCRIPTION
I am working on interfacing this with Drupal file services.  They just recently made a change to where every request must be signed before it can be sent to the server with an Authentication token to stop XSRF.  When they made this change, the file uploads stopped working.  I made a change to your library that allows a derived class to sign a request before it is sent out, and then properly decode the response when it comes back...

```
Ext.define('DrupalTouch.ux.DrupalFile', {
  extend: 'Ext.ux.Fileup',
  xtype: 'drupalfile',
  requires: [
    'Ext.ux.Fileup'
  ],
  file: null,
  signRequest: function(http, callback) {
    Ext.Ajax.request({
      url: '/services/session/token',
      method: 'GET',
      success: function(response) {
        http.setRequestHeader("X-CSRF-Token", response.responseText);
        callback(http);
      }
    });
  },
  decodeResponse: function(response) {
    if (response.responseText) {

      // Get the drupal file from the response text.
      this.file = Ext.JSON.decode(response.responseText);
      return {success: true};
    }
    else {
      return {
        success: false,
        message: 'File upload failed'
      }
    }
  }
});
```

This PR adds this ability.  I appreciate this library.
