### PR TITLE
Sencha Touch loading Spinner name fix

### DIFF
--- a/src/ux/sass/_FileUp.scss
+++ b/src/ux/sass/_FileUp.scss
@@ -18,7 +18,7 @@
 }
 
 $loading-spinner-color: #000000;
-@include sencha-loading-spinner;
+@include st-loading-spinner;
 .x-fileup-uploading {
     .x-loading-spinner {
         font-size: 100%;


### PR DESCRIPTION
sencha-loading-spinner did not work for me but st-loading-spinner worked.  Sencha Touch 2.2.1
